### PR TITLE
Upload hobby picture

### DIFF
--- a/server/routes/hobby.ts
+++ b/server/routes/hobby.ts
@@ -147,4 +147,23 @@ hobbyRouter.post('/activate', async (req: Request, res: Response) => {
     }
 });
 
+/**
+ * Загрузка аватара
+ * id хобби - параметр запроса
+ */
+hobbyRouter.post('/upload', upload.single('avatar'), async (req: Request, res: Response) => {
+    if (!req.session?.provider) {
+        res.status(HTTP_STATUS.FORBIDDEN).send('Текущий партнёр не прошел авторизацию');
+        return;
+    }
+    try {
+        const {id} = req.query;
+        await HobbyServiceInstance.AvatarUpload(id, req.file)
+        res.status(HTTP_STATUS.OK).send();
+    } catch (e) {
+        const {status, message} = processError(e);
+        res.status(status).send(message);
+    }
+});
+
 export default hobbyRouter;

--- a/server/services/hobby.ts
+++ b/server/services/hobby.ts
@@ -76,4 +76,12 @@ export default class HobbyService {
         });
         return this.Hobby.findByIdAndUpdate(hobbyId, {monetization: nextMonetization})
     }
+
+    async AvatarUpload(hobbyId: string, file?: Express.Multer.File) {
+        if (!file) {
+            throw {status: HTTP_STATUS.BAD_REQUEST, message: 'Нет файла'}
+        }
+        const url = await uploadFileToS3('hobbies', file);
+        return this.Hobby.findByIdAndUpdate(hobbyId, {avatar: url}, {new: true});
+    }
 }


### PR DESCRIPTION
Добавлены контроллер и сервис для загрузки фотографии хобби. Здесь я сделал немного другую логику, чем при добавлении пользователя.

Там все данные отправляются через multipart/form-data: они идут все одним запросом, но отправку вложенных объектов приходится хардкодить как JSON.strigify(...) --> JSON.parse(...). Минусы такого подхода, которые мне видятся: 
1) Выглядит не очень красиво, как костыль
2) Приходится явно перечислять какие-то отдельные "проблемные" свойства непосредственно в коде, что его усложняет и запутывает (а если эти свойства изменятся в моделях или добавятся новые? Всё придётся изменять).

Здесь отправка данных происходит в 2 стадии. Сначала отправляется вся информация о хобби, кроме аватарки, причём происходит это "как обычно" (т.е. в x-www-form-urlencoded), что позволяет очень просто отправить и обработать запрос. Потом отдельно посылается картинка, уже через multipart/form-data, и обрабатывается в отдельном сервисе. Мне кажется, что это лучше, чем то, что происходит при добавлении пользователя: по крайней мере, такой код лишён второй проблемы из упомянутых выше.